### PR TITLE
chore: SHA-pin conventional-actions to latest hardened versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Generate next version
         id: semver
-        uses: conventional-actions/next-version@v1
+        uses: conventional-actions/next-version@c6672ae04a946e12f361b119d3fd8fbb3388c0d9 # v1
       - name: Create Draft Release
         uses: ncipollo/release-action@v1
         with:
@@ -77,7 +77,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Setup .netrc
-        uses: conventional-actions/setup-netrc@v1
+        uses: conventional-actions/setup-netrc@4f85df605083085682fc078d17b5d15e439a924e # v1
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,14 @@ jobs:
           secret-files: |
             "netrc=/home/runner/.netrc"
       # - name: Run Snyk for linux/amd64
-      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
+      #   uses: snyk/actions/docker@master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
       #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
       # - name: Run Snyk for linux/arm64
-      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
+      #   uses: snyk/actions/docker@master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,14 @@ jobs:
           secret-files: |
             "netrc=/home/runner/.netrc"
       # - name: Run Snyk for linux/amd64
-      #   uses: snyk/actions/docker@master
+      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
       #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
       # - name: Run Snyk for linux/arm64
-      #   uses: snyk/actions/docker@master
+      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
@@ -171,7 +171,7 @@ jobs:
   #   needs:
   #     - draft-release
   #     - release
-  #   uses: ketch-com/crew/.github/workflows/uat.yml@main
+  #   uses: ketch-com/crew/.github/workflows/uat.yml@d1986d1db9398c6754c51772d98e9a50b3ca7467 # main
   #   with:
   #     version: ${{ needs.draft-release.outputs.version-patch }}
   #     service: ketch-event-forwarder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
   #   needs:
   #     - draft-release
   #     - release
-  #   uses: ketch-com/crew/.github/workflows/uat.yml@d1986d1db9398c6754c51772d98e9a50b3ca7467 # main
+  #   uses: ketch-com/crew/.github/workflows/uat.yml@main
   #   with:
   #     version: ${{ needs.draft-release.outputs.version-patch }}
   #     service: ketch-event-forwarder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
       version-patch: ${{ format('{0}.{1}.{2}', steps.semver.outputs.version-major-only, steps.semver.outputs.version-minor-only, steps.semver.outputs.version-patch-only) }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Generate next version
         id: semver
         uses: conventional-actions/next-version@c6672ae04a946e12f361b119d3fd8fbb3388c0d9 # v1
       - name: Create Draft Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:
           prerelease: true
           draft: false
@@ -61,34 +61,34 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # - name: Configure AWS Credentials
-      #   uses: aws-actions/configure-aws-credentials@v2
+      #   uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
       #   with:
       #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       #     aws-region: us-west-2
       # - name: Login to Amazon ECR
       #   id: login-ecr
-      #   uses: aws-actions/amazon-ecr-login@v1
+      #   uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
       #   with:
       #     registries: "337034319268"
       #     mask-password: "true"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Setup .netrc
         uses: conventional-actions/setup-netrc@4f85df605083085682fc078d17b5d15e439a924e # v1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ${{ matrix.images.githubRegistry }}
@@ -99,13 +99,13 @@ jobs:
             type=raw,value=${{ needs.draft-release.outputs.version-minor }}
             type=raw,value=${{ needs.draft-release.outputs.version-patch }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ env.GITHUB_TOKEN }}
       - name: Build docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         id: dockerbuild
         with:
           context: .
@@ -132,7 +132,7 @@ jobs:
       #     image: ${{ matrix.images.localRegistry }}:latest
       #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/arm64
       - name: Push docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           platforms: linux/arm64,linux/amd64
@@ -158,7 +158,7 @@ jobs:
       contents: write
     steps:
       - name: Finalize release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:
           allowUpdates: true
           tag: ${{ needs.draft-release.outputs.version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,14 +58,14 @@ jobs:
           secret-files: |
             "netrc=/home/runner/.netrc"
       # - name: Run Snyk for linux/amd64
-      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
+      #   uses: snyk/actions/docker@master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
       #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
       # - name: Run Snyk for linux/arm64
-      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
+      #   uses: snyk/actions/docker@master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Setup .netrc
-        uses: conventional-actions/setup-netrc@v1
+        uses: conventional-actions/setup-netrc@4f85df605083085682fc078d17b5d15e439a924e # v1
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,27 +25,27 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Setup .netrc
         uses: conventional-actions/setup-netrc@4f85df605083085682fc078d17b5d15e439a924e # v1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: network=host
       # - name: Login to GitHub Container Registry
-      #   uses: docker/login-action@v3
+      #   uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       #   with:
       #     registry: ghcr.io
       #     username: ${{ github.repository_owner }}
       #     password: ${{ env.GITHUB_TOKEN }}
       - name: Build docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         id: dockerbuild
         with:
           context: .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,14 +58,14 @@ jobs:
           secret-files: |
             "netrc=/home/runner/.netrc"
       # - name: Run Snyk for linux/amd64
-      #   uses: snyk/actions/docker@master
+      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
       #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
       # - name: Run Snyk for linux/arm64
-      #   uses: snyk/actions/docker@master
+      #   uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:


### PR DESCRIPTION
## Summary
- Pin all `conventional-actions/*` workflow references to full commit SHAs
- All referenced conventional-actions repos have been updated and tested upstream

## Why
Tags can be moved by attackers who compromise a repository. SHAs are immutable, preventing supply-chain attacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 766ed5eee425bbcb518d179e4aa1c387515a68b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->