### PR TITLE
fix: upgrade conventional-actions to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Generate next version
         id: semver
-        uses: conventional-actions/next-version@c6672ae04a946e12f361b119d3fd8fbb3388c0d9 # v1
+        uses: conventional-actions/next-version@1b3e4803a0bdf7435ba7bb5ace077445ed54e82a # v1.1.8
       - name: Create Draft Release
         uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:


### PR DESCRIPTION
## Summary

Upgrade conventional-actions to node24-compatible releases:

- `conventional-actions/next-version` → **v1.1.8** (`1b3e480`)
- `conventional-actions/create-release` → **v1.0.31** (`c025b73`)

Node 20 reaches EOL April 2026 and GitHub is forcing migration to node24 by June 2026.

### Upstream PRs

- https://github.com/conventional-actions/next-version/pull/96
- https://github.com/conventional-actions/create-release/pull/8

## Test plan

- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a pinned GitHub Action SHA is updated, with behavior changes limited to version calculation in the release workflow. If upstream output semantics changed, it could impact tagging/release automation.
> 
> **Overview**
> **CI release automation is updated** to use `conventional-actions/next-version@v1.1.8` (new pinned SHA) when generating the next version in `.github/workflows/ci.yml`.
> 
> No application/runtime code changes; the impact is limited to how the workflow computes and tags releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7accd24b54a0458e5562a8e7fb7ae7a78dfa412f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->