### PR TITLE
fix(ci): add --org=ketch-com to Snyk scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,14 @@ jobs:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
-      #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
+      #     args: --org=ketch-com --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
       # - name: Run Snyk for linux/arm64
       #   uses: snyk/actions/docker@master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
-      #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/arm64
+      #     args: --org=ketch-com --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/arm64
       - name: Push docker images
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,14 +63,14 @@ jobs:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
-      #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
+      #     args: --org=ketch-com --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/amd64
       # - name: Run Snyk for linux/arm64
       #   uses: snyk/actions/docker@master
       #   env:
       #     SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
       #   with:
       #     image: ${{ matrix.images.localRegistry }}:latest
-      #     args: --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/arm64
+      #     args: --org=ketch-com --file=${{ env.DOCKERFILE }} --severity-threshold=high --platform=linux/arm64
 
 concurrency:
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Add `--org=ketch-com` to all Snyk action args in CI/PR workflows
- Without this flag, Snyk defaults to the `ketch-robot` personal org which **lacks container scanning entitlements** (returns 403 Forbidden)
- The `ketch-com` Snyk org has the paid subscription and should be used for all scans

## Context

This was discovered while fixing the `base-images` repo — all Snyk scans across all repos were silently using the wrong org. See https://github.com/ketch-com/base-images/pull/49

## Test plan

- [ ] CI Snyk scan passes (no more 403 Forbidden)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions workflow configuration (commented Snyk scan arguments) with no impact to runtime application code.
> 
> **Overview**
> Ensures the Snyk Docker scan commands in `ci.yml` and `pr.yml` (currently commented out) include `--org=ketch-com` in their `args` for both `linux/amd64` and `linux/arm64`, so scans target the correct Snyk organization when enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f34b760a139d03f8428a5b2b181a1d719de7ee06. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->